### PR TITLE
Update `therubyracer` gem

### DIFF
--- a/jshint.gemspec
+++ b/jshint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "therubyracer", "~> 0.10.2"
+  spec.add_dependency "therubyracer", "~> 0.12.1"
   spec.add_dependency "execjs", "~> 1.4.0"
   spec.add_dependency "railties", ">= 3.2.0"
   spec.add_dependency 'multi_json', '~> 1.0'


### PR DESCRIPTION
The older version of `therubyracer` gem, which jshint depends on, is not compatible with OSX Mavericks and will cause compilation issues.

Please reference too: http://stackoverflow.com/questions/19630154/gem-install-therubyracer-v-0-10-2-on-osx-mavericks-not-installing 

PS. All tests are still passing :)  Thanks for the great gem.
