### PR TITLE
Update version of jsexec required.

### DIFF
--- a/jshint.gemspec
+++ b/jshint.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "therubyracer", "~> 0.12.1"
-  spec.add_dependency "execjs", ">= 2.2.0"
+  spec.add_dependency "execjs", ">= 1.4.0"
   spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Later versions of Rails use newer jsexec versions. This shouldn't break anything.
