### PR TITLE
Allow jshint to be used standalone

### DIFF
--- a/bin/jshint
+++ b/bin/jshint
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+$LOAD_PATH.unshift(File.dirname(File.realpath(__FILE__)) + '/../lib')
+
+require 'jshint'
+require 'jshint/reporters'
+require 'jshint/cli'
+
+reporter_name = ARGV[0] || :Default
+result_file = ARGV[1]
+
+Jshint::Cli::run(reporter_name, result_file)

--- a/lib/jshint/cli.rb
+++ b/lib/jshint/cli.rb
@@ -1,6 +1,6 @@
 module Jshint
   module Cli
-    def run(reporter_name = :Default, result_file = nil)
+    def self.run(reporter_name = :Default, result_file = nil)
       linter = Jshint::Lint.new
       linter.lint
       reporter = Jshint::Reporters.const_get(reporter_name).new(linter.errors)
@@ -10,8 +10,8 @@ module Jshint
       end
 
       if result_file
-        Dir.mkdir(File.dirname(file))
-        File.open(file, 'w') do |stream|
+        Dir.mkdir(File.dirname(result_file))
+        File.open(result_file, 'w') do |stream|
           printer.call(stream)
         end
       else

--- a/lib/jshint/cli.rb
+++ b/lib/jshint/cli.rb
@@ -1,0 +1,22 @@
+module Jshint
+  module Cli
+    def run(reporter_name = :Default, result_file = nil)
+      linter = Jshint::Lint.new
+      linter.lint
+      reporter = Jshint::Reporters.const_get(reporter_name).new(linter.errors)
+
+      printer = lambda do |stream|
+        stream.puts reporter.report
+      end
+
+      if result_file
+        Dir.mkdir(File.dirname(file))
+        File.open(file, 'w') do |stream|
+          printer.call(stream)
+        end
+      else
+        printer.call($stdout)
+      end
+    end
+  end
+end

--- a/lib/jshint/tasks/jshint.rake
+++ b/lib/jshint/tasks/jshint.rake
@@ -1,30 +1,17 @@
 require 'jshint'
 require 'jshint/reporters'
+require 'jshint/cli'
 
 namespace :jshint do
   desc "Runs JSHint, the JavaScript lint tool over this project's JavaScript assets"
   task :lint => :environment do |_, args|
     # Our own argument parsing, since rake jshint will push extra nil's.
     reporter_name = :Default
-    file = nil
+    result_file = nil
     reporter_name = args.extras[0] if args.extras.length >= 1
-    file = args.extras[1] if args.extras.length >= 2
+    result_file = args.extras[1] if args.extras.length >= 2
 
-    linter = Jshint::Lint.new
-    linter.lint
-    reporter = Jshint::Reporters.const_get(reporter_name).new(linter.errors)
-
-    printer = lambda do |stream|
-      stream.puts reporter.report
-    end
-    if file
-	    Dir.mkdir(File.dirname(file))
-      File.open(file, 'w') do |stream|
-        printer.call(stream)
-      end
-    else
-      printer.call($stdout)
-    end
+    Jshint::Cli::run(reporter_name, result_file)
   end
 
   desc "Copies the default JSHint options to your Rails application"


### PR DESCRIPTION
So that this only needs installation on CI servers and not necessarily remain in gemfiles, like what Rubocop and Scss-lint allows.