### PR TITLE
Fail the Rake task if there are linting errors

### DIFF
--- a/lib/jshint/tasks/jshint.rake
+++ b/lib/jshint/tasks/jshint.rake
@@ -25,6 +25,8 @@ namespace :jshint do
     else
       printer.call($stdout)
     end
+
+    fail if linter.errors.any? { |_, errors| errors.any? }
   end
 
   desc "Copies the default JSHint options to your Rails application"


### PR DESCRIPTION
When linting as part of a test suite, the expected behaviour is for
errors to break the build.

See also #16 for an alternative implementation.