### PR TITLE
Run specs via Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,9 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+task :default => [:spec]
+
+desc "Run the specs."
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "spec/**/*_spec.rb"
+end


### PR DESCRIPTION
It's a common convention in Ruby projects that `rake` will run the test suite.