### PR TITLE
RSpec upgrade

### DIFF
--- a/jshint.gemspec
+++ b/jshint.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "railties", ">= 3.2.0"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "rspec", "~> 2.99"
   spec.add_development_dependency "yard"
 end

--- a/jshint.gemspec
+++ b/jshint.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "railties", ">= 3.2.0"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 2.99"
+  spec.add_development_dependency "rspec", "~> 3.1.0"
   spec.add_development_dependency "yard"
 end

--- a/spec/jshint_spec.rb
+++ b/spec/jshint_spec.rb
@@ -4,7 +4,7 @@ require 'jshint'
 describe Jshint do
   describe ".class methods" do
     it "should return the root path of the gem" do
-      described_class.root.should == File.expand_path('../..', __FILE__)
+      expect(described_class.root).to eq(File.expand_path('../..', __FILE__))
     end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -12,8 +12,8 @@ describe Jshint::Configuration do
 
     it "should allow the developer to index in to config options" do
       config = described_class.new
-      config[:boss].should be_true
-      config[:browser].should be_true
+      config[:boss].should be_truthy
+      config[:browser].should be_truthy
     end
 
     it "should return a Hash of the global variables declared" do

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -6,47 +6,51 @@ describe Jshint::Configuration do
 
   describe "core behaviour" do
     before do
-      described_class.any_instance.stub(:default_config_path).and_return('/foo/bar.yml')
-      described_class.any_instance.stub(:parse_yaml_config).and_return(YAML.load_file(config))
+      allow_any_instance_of(described_class).
+        to receive(:default_config_path).and_return('/foo/bar.yml')
+      allow_any_instance_of(described_class).
+        to receive(:parse_yaml_config).and_return(YAML.load_file(config))
     end
 
     it "should allow the developer to index in to config options" do
       config = described_class.new
-      config[:boss].should be_truthy
-      config[:browser].should be_truthy
+      expect(config[:boss]).to be_truthy
+      expect(config[:browser]).to be_truthy
     end
 
     it "should return a Hash of the global variables declared" do
       config = described_class.new
-      config.global_variables.should == { "jQuery" => true, "$" => true }
+      expect(config.global_variables).to eq({ "jQuery" => true, "$" => true })
     end
 
     it "should return a Hash of the lint options declared" do
       config = described_class.new
-      config.lint_options.should == config.options["options"].reject { |key| key == "globals" }
+      expect(config.lint_options).
+        to eq(config.options["options"].reject { |key| key == "globals" })
     end
 
     it "should return an array of files" do
       config = described_class.new
-      config.files.should == ["**/*.js"]
+      expect(config.files).to eq(["**/*.js"])
     end
 
     context "search paths" do
       subject { described_class.new }
 
       it "should default the exclusion paths to an empty array" do
-        subject.excluded_search_paths.should == []
+        expect(subject.excluded_search_paths).to eq([])
       end
 
       it "should set the exclusion paths to those in the config" do
         subject.options["exclude_paths"] << 'vendor/assets/javascripts'
-        subject.excluded_search_paths.should == ["vendor/assets/javascripts"]
+        expect(subject.excluded_search_paths).to eq(["vendor/assets/javascripts"])
       end
 
       it "should be the default search paths minus the exclude paths" do
-        subject.search_paths.should == subject.default_search_paths
+        expect(subject.search_paths).to eq(subject.default_search_paths)
         subject.options["exclude_paths"] << 'vendor/assets/javascripts'
-        subject.search_paths.should == ['app/assets/javascripts', 'lib/assets/javascripts']
+        expect(subject.search_paths).
+          to eq(['app/assets/javascripts', 'lib/assets/javascripts'])
       end
     end
   end

--- a/spec/lib/lint_spec.rb
+++ b/spec/lib/lint_spec.rb
@@ -27,7 +27,7 @@ describe Jshint::Lint do
     subject.get_json(hash)
   end
 
-  describe :lint do
+  describe "lint" do
     before do
       subject.stub(:javascript_files).and_return(files)
       subject.stub(:jshint_options).and_return(opts)

--- a/spec/lib/lint_spec.rb
+++ b/spec/lib/lint_spec.rb
@@ -9,72 +9,74 @@ describe Jshint::Lint do
   let(:globals)       { MultiJson.dump({ :jquery => true, :app => true }) }
 
   subject do
-    Jshint::Configuration.stub(:new).and_return(configuration)
+    allow(Jshint::Configuration).to receive(:new).and_return(configuration)
     described_class.new
   end
 
   it "should initialize errors to an empty Hash" do
-    subject.errors.should be_a Hash
+    expect(subject.errors).to be_a Hash
   end
 
   it "should assing the Configration object to config" do
-    subject.config.should == configuration
+    expect(subject.config).to eq(configuration)
   end
 
   it "should respond to get_json" do
     hash = { :hello => 'world' }
-    MultiJson.should_receive(:dump).with(hash)
+    expect(MultiJson).to receive(:dump).with(hash)
     subject.get_json(hash)
   end
 
   describe "lint" do
     before do
-      subject.stub(:javascript_files).and_return(files)
-      subject.stub(:jshint_options).and_return(opts)
-      subject.stub(:jshint_globals).and_return(globals)
+      allow(subject).to receive(:javascript_files).and_return(files)
+      allow(subject).to receive(:jshint_options).and_return(opts)
+      allow(subject).to receive(:jshint_globals).and_return(globals)
     end
 
     context "invalid file" do
       before do
-        subject.stub(:get_file_content_as_json).and_return(subject.get_json(<<-eos
-            var foo = "bar",
-                baz = "qux",
-                bat;
+        allow(subject).to receive(:get_file_content_as_json).
+          and_return(subject.get_json(<<-eos
+              var foo = "bar",
+                  baz = "qux",
+                  bat;
 
-            if (foo == baz) bat = "gorge" // no semicolon and single line
-          eos
-        ))
+              if (foo == baz) bat = "gorge" // no semicolon and single line
+            eos
+          ))
         subject.lint
       end
 
       it "should add two error messages to the errors Hash" do
-        subject.errors[file].length.should == 2
+        expect(subject.errors[file].length).to eq(2)
       end
     end
 
     context "valid file" do
       before do
-        subject.stub(:get_file_content_as_json).and_return(subject.get_json(<<-eos
-            var foo = "bar",
-                baz = "qux",
-                bat;
+        allow(subject).to receive(:get_file_content_as_json).
+          and_return(subject.get_json(<<-eos
+              var foo = "bar",
+                  baz = "qux",
+                  bat;
 
-            if (foo == baz) {
-              bat = "gorge";
-              var x = "foo"; // jshint ignore:line
-            }
-          eos
-        ))
+              if (foo == baz) {
+                bat = "gorge";
+                var x = "foo"; // jshint ignore:line
+              }
+            eos
+          ))
         subject.lint
       end
 
       it "should retrieve the files content" do
-        subject.should_receive(:get_file_content_as_json).with(file)
+        expect(subject).to receive(:get_file_content_as_json).with(file)
         subject.lint
       end
 
       it "should add two error messages to the errors Hash" do
-        subject.errors[file].length.should == 0
+        expect(subject.errors[file].length).to eq(0)
       end
     end
   end

--- a/spec/lib/reporters/default_spec.rb
+++ b/spec/lib/reporters/default_spec.rb
@@ -46,20 +46,20 @@ describe Jshint::Reporters::Default do
   subject { described_class.new(results) }
 
   it "should initialize output to be an empty string" do
-    subject.output.should == ''
+    expect(subject.output).to eq('')
   end
 
   describe "print_footer" do
     it "should output a footer starting with a new line feed" do
-      subject.print_footer(3).start_with?("\n").should be_truthy
+      expect(subject.print_footer(3)).to start_with("\n")
     end
 
     it "should output a footer containing '3 errors'" do
-      subject.print_footer(3).should include "3 errors"
+      expect(subject.print_footer(3)).to include("3 errors")
     end
 
     it "should output a footer containing '1 error'" do
-      subject.print_footer(1).should include "1 error"
+      expect(subject.print_footer(1)).to include("1 error")
     end
   end
 
@@ -69,44 +69,44 @@ describe Jshint::Reporters::Default do
     end
 
     it "should add 3 entries in to the error output" do
-      subject.output.split(/\r?\n/).length.should == 3
+      expect(subject.output.split(/\r?\n/).length).to eq(3)
     end
 
     it "should contain the line number in to the error output" do
-      subject.output.should include "line 1"
+      expect(subject.output).to include("line 1")
     end
 
     it "should contain the column number in to the error output" do
-      subject.output.should include "col 1"
+      expect(subject.output).to include("col 1")
     end
 
     it "should contain the filename in to the error output" do
-      subject.output.should include "app/assets/javascripts/angular/controllers/feeds_controller.js"
+      expect(subject.output).to include("app/assets/javascripts/angular/controllers/feeds_controller.js")
     end
 
     it "should contain the nature of the error in to the error output" do
-      subject.output.should include "'app' is not defined"
+      expect(subject.output).to include("'app' is not defined")
     end
   end
 
   describe "report" do
     it "should call print errors for file 1 time" do
-      subject.should_receive(:print_errors_for_file)
+      expect(subject).to receive(:print_errors_for_file)
       subject.report
     end
 
     it "should print the report footer" do
-      subject.should_receive(:print_footer).with(3)
+      expect(subject).to receive(:print_footer).with(3)
       subject.report
     end
 
     it "should return a thorough report" do
-      subject.report.length.should >= 10
+      expect(subject.report.length).to be >= 10
     end
 
     it "should return 0 errors when it has no results" do
       subject.instance_variable_set(:@results, {})
-      subject.report.should include "0 errors"
+      expect(subject.report).to include "0 errors"
     end
   end
 end

--- a/spec/lib/reporters/default_spec.rb
+++ b/spec/lib/reporters/default_spec.rb
@@ -49,9 +49,9 @@ describe Jshint::Reporters::Default do
     subject.output.should == ''
   end
 
-  describe :print_footer do
+  describe "print_footer" do
     it "should output a footer starting with a new line feed" do
-      subject.print_footer(3).start_with?("\n").should be_true
+      subject.print_footer(3).start_with?("\n").should be_truthy
     end
 
     it "should output a footer containing '3 errors'" do
@@ -63,7 +63,7 @@ describe Jshint::Reporters::Default do
     end
   end
 
-  describe :print_errors_for_file do
+  describe "print_errors_for_file" do
     before do
       subject.print_errors_for_file("app/assets/javascripts/angular/controllers/feeds_controller.js", results["app/assets/javascripts/angular/controllers/feeds_controller.js"])
     end
@@ -89,7 +89,7 @@ describe Jshint::Reporters::Default do
     end
   end
 
-  describe :report do
+  describe "report" do
     it "should call print errors for file 1 time" do
       subject.should_receive(:print_errors_for_file)
       subject.report

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,4 +10,9 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+
+  # Require the RSpec 3 "expect()" syntax
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'coveralls'
 Coveralls.wear!
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
Upgrade RSpec dependency to at least 3.1, fix deprecation warnings, and switch to the new `expect()` syntax.

Fixes #19.