### PR TITLE
Fix default Rake task

### DIFF
--- a/lib/jshint/tasks/jshint.rake
+++ b/lib/jshint/tasks/jshint.rake
@@ -6,8 +6,8 @@ namespace :jshint do
   desc "Runs JSHint, the JavaScript lint tool over this project's JavaScript assets"
   task :lint => :environment do |_, args|
     # Our own argument parsing, since rake jshint will push extra nil's.
-    reporter_name = args.extras[0] if args.extras.length >= 1
-    result_file = args.extras[1] if args.extras.length >= 2
+    reporter_name = args.extras[0] || :Default
+    result_file = args.extras[1]
 
     linter = Jshint::Cli::run(reporter_name, result_file)
     fail if linter.errors.any? { |_, errors| errors.any? }


### PR DESCRIPTION
Commit 7f9dbe6 removed the default value for reporter_name, which meant that "rake jshint" no longer works in version 1.3.0.

Ideally, we'd have some tests for this, but I'm not sure how to achieve that. In the meantime, let's settle for restoring full functionality.

Fixes #21.