### PR TITLE
Remove the dependency on the ruby racer.

### DIFF
--- a/jshint.gemspec
+++ b/jshint.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "therubyracer", "~> 0.12.1"
   spec.add_dependency "execjs", ">= 1.4.0"
   spec.add_dependency 'multi_json', '~> 1.0'
 

--- a/lib/jshint/version.rb
+++ b/lib/jshint/version.rb
@@ -1,4 +1,4 @@
 module Jshint
   # Our gem version
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
I love the gem, but instead of having a dependency on therubyracer, we can leave the selection of the JS runtimes up to the user (node, therubyrhino, JavaScriptCore). This convention follows the jshintrb gem and gives more flexibility with no functional loss.

Updated the minor version since some users may depend on this gem to include therubyracer.