### PR TITLE
Fix ability to add search path subdirectory to excluded paths (Issue #28)

### DIFF
--- a/lib/jshint/lint.rb
+++ b/lib/jshint/lint.rb
@@ -96,11 +96,15 @@ module Jshint
       js_asset_files = []
       file_paths.each do |path|
         Dir.glob(path) do |file|
-          js_asset_files << file
+          js_asset_files << file.reject {|file| exclude_file?(file)}
         end
       end
 
       js_asset_files
+    end
+
+    def exclude_file?(file)
+      config.excluded_search_paths.any? {|path| file.include?(path)}
     end
   end
 end

--- a/lib/jshint/version.rb
+++ b/lib/jshint/version.rb
@@ -1,4 +1,4 @@
 module Jshint
   # Our gem version
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/spec/lib/lint_spec.rb
+++ b/spec/lib/lint_spec.rb
@@ -79,5 +79,35 @@ describe Jshint::Lint do
         expect(subject.errors[file].length).to eq(0)
       end
     end
+
+    context "excluded subdirectory" do
+      let(:search_paths) { [ 'app/assets/javascripts' ] }
+      let(:excluded_search_paths) { [ 'app/assets/javascripts/i18n' ] }
+      let(:excluded_file) { 'app/assets/javascripts/i18n/test.js' }
+      let(:files) { '**/*.js' }
+      let(:javascript_files) { [file, excluded_file] }
+
+      before do
+        allow(subject).to receive(:javascript_files).and_call_original
+        allow(configuration).to receive(:search_paths).and_return(search_paths)
+        allow(configuration).to receive(:excluded_search_paths).and_return(excluded_search_paths)
+        allow(configuration).to receive(:files).and_return(files)
+        allow(Dir).to receive(:glob).and_yield(javascript_files)
+        allow(subject).to receive(:get_file_content_as_json).
+          and_return(subject.get_json(<<-eos
+              var foo = "bar",
+                  baz = "qux",
+                  bat;
+
+              if (foo == baz) bat = "gorge" // no semicolon and single line
+            eos
+          ))
+      end
+
+      it "shouldn't load files in excluded subdirectory" do
+        expect(subject).to receive(:get_file_content_as_json).with([file])
+        subject.lint
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix for issue #28. Test stubs got a bit weird, so that may be a sign that the filepath searching logic might be better to move into the configuration object or something.