### PR TITLE
coveralls has some wonky dependencies, we can use an older version maybe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/jshint.gemspec
+++ b/jshint.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.1.0"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "tins", "~> 1.6.0"
+  spec.add_development_dependency 'term-ansicolor', '~> 1.3.0'
+  spec.add_development_dependency 'json', "~> 1.8.3"
 end


### PR DESCRIPTION
we should probably add a Gemfile.lock file here, or add a version to the coveralls gem
adding the following dependencies allowed me to install bundle in 1.9.3