### PR TITLE
Update rspec dep to work with newest rake

### DIFF
--- a/jshint.gemspec
+++ b/jshint.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "railties", ">= 3.2.0", "< 5.0.0"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.1.0"
+  spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "tins", "~> 1.6.0"
   spec.add_development_dependency 'term-ansicolor', '~> 1.3.0'


### PR DESCRIPTION
rspec v3.1 uses a deprecated and now removed rake API:

```
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000003344a10>
/home/czimmer/.rvm/gems/ruby-2.3.1/gems/rspec-core-3.1.7/lib/rspec/core/rake_task.rb:104:in `define'
```